### PR TITLE
add permissions to allow OPTIONS request

### DIFF
--- a/images/tls/pound.cfg
+++ b/images/tls/pound.cfg
@@ -43,7 +43,8 @@ ListenHTTPS
 	Port	443
 
 	## allow PUT and DELETE also (by default only GET, POST and HEAD)?:
-	xHTTP	1
+	## allow (between other actions) OPTIONS requests for REST with CORS
+	xHTTP	2
 
 	HeadRemove	"X-Forwarded-Proto"
 	AddHeader	"X-Forwarded-Proto: https"


### PR DESCRIPTION
Edited pound.cfg config file to allow to pass OPTIONS request into the Magento instance.

<!---
    Thank you for contributing to Magento.
    To help us process this pull request we recommend that you add the following information:
     - Summary of the pull request,
     - Issue(s) related to the changes made,
     - Manual testing scenarios,
-->

This merge allows to pass from TSL container all the request using the OPTIONS header into the chain of request. This is required when using CORS on the REST API calls.

### Description
To allow to make the OPTIONS calls from the pound system into the chain up to Magento to decide the response, we need to allow pound to handle this http method.
Without this change the OPTIONS call returns a 501 Not implemented error code on the OPTION call.
This is only required when using CORS to allow to use the Magento API from another domain.

### Fixed Issues (if relevant)
Cannot send issues into the repository as the option is not available 

### Manual testing scenarios
Without the merge request:
`
curl -v --location --request OPTIONS 'https://magento2.docker/rest/all/V1/integration/admin/token''
`
Response code is 501 Not implemented

### Contribution checklist
 - [ ] Pull request has a meaningful description of its purpose
 - [ ] All commits are accompanied by meaningful commit messages